### PR TITLE
Secondary MySQL in Vagrantfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,18 @@ stage-mongodb-setup: /usr/share/doc/mongodb-server /etc/sandcats-meteor-settings
 	sudo cp conf/mongodb.conf /etc/
 	sudo service mongodb restart
 
-stage-mysql-setup: /usr/share/doc/mysql-server
+stage-mysql-setup: /usr/share/doc/mysql-server /etc/mysql/conf.d/sandcats-replication.cnf
 	echo 'create database if not exists sandcats_pdns;' | mysql -uroot
 	# The following is a fancy way to only run the SQL queries if they have
 	# not already been already run.
 	echo 'show tables like "domains"' | mysql -uroot sandcats_pdns | grep -q . || mysql -uroot sandcats_pdns < /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
 	echo "GRANT ALL on sandcats_pdns.* TO 'sandcats_pdns'@'localhost' IDENTIFIED BY '3Rb4k4BQqKr59Ewj';" | mysql -uroot
+
+/etc/mysql/conf.d/sandcats-replication.cnf: conf/sandcats-replication.cnf
+	sudo cp conf/sandcats-replication.cnf /etc/mysql/conf.d/sandcats-replication.cnf
+	sudo service mysql restart
+
+	# Enable binlogging, so that we can have replication.
 
 stage-pdns-setup: /etc/powerdns/pdns.d/pdns.sandcats.conf
 	# Now that we know our conf file has been slotted into place,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # machine.
     secondary.vm.network :private_network, ip: "169.254.253.3"
 
-    secondary.vm.provision "shell", inline: "cd /vagrant/secondary && sudo apt-get update && sudo -u vagrant MYSQL_PRIMARY_IP_ADDRESS=169.254.253.3 make stage-provision"
+    secondary.vm.provision "shell", inline: "cd /vagrant/secondary && sudo apt-get --quiet=2 update && sudo -u vagrant MYSQL_PRIMARY_IP_ADDRESS=169.254.253.2 make stage-before-authorize"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,28 +9,52 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # we can have systemd.
   config.vm.box = "thoughtbot/debian-jessie-64"
 
-  # Accessing "localhost:8443" will access port 443 on the guest
-  # machine.
-  config.vm.network "forwarded_port", guest: 443, host: 8443
+  # This Vagrantfile creates two machines: the main machine, and a
+  # secondary.
+  #
+  # The idea is to have the Vagrantfile effectively simulate bringing
+  # up the production instances, where we need a main worker VM with
+  # the web interface and also a secondary DNS server.
+  config.vm.define "main", primary: true do |main|
 
-  # Expose port 80 (HTTP) as 8080 (TCP) for the HTTP (non HTTPS)
-  # view of the Meteor site.
-  config.vm.network "forwarded_port", guest: 80, host: 8080,
-                    protocol: 'tcp'
+    # Accessing "localhost:8443" will access port 443 on the guest
+    # machine.
+    main.vm.network "forwarded_port", guest: 443, host: 8443
 
-  # Expose port 8080 (UDP), for the meta-update protocol.
-  config.vm.network "forwarded_port", guest: 8080, host: 8080,
+    # Expose port 80 (HTTP) as 8080 (TCP) for the HTTP (non HTTPS)
+    # view of the Meteor site.
+    main.vm.network "forwarded_port", guest: 80, host: 8080,
+                   protocol: 'tcp'
+
+    # Expose port 8080 (UDP), for the meta-update protocol.
+    main.vm.network "forwarded_port", guest: 8080, host: 8080,
                     protocol: 'udp'
 
-  # Expose DNS in the guest as 8053 (UDP), for DNS queries.
-  config.vm.network "forwarded_port", guest: 53, host: 8053,
-                    protocol: 'udp'
+    # Expose DNS in the guest as 8053 (UDP), for DNS queries.
+    main.vm.network "forwarded_port", guest: 53, host: 8053,
+                      protocol: 'udp'
 
-  # Create a private host<->guest network, mostly for NFS.
-  config.vm.network :private_network, ip: "169.254.253.2"
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+    # Create a private host<->guest network, mostly for NFS.
+    main.vm.network :private_network, ip: "169.254.253.2"
+    main.vm.synced_folder ".", "/vagrant", type: "nfs"
 
-  # Use a shell script that contains steps required to initialize a
-  # sandcats server.
-  config.vm.provision "shell", inline: "cd /vagrant && sudo apt-get update && sudo -u vagrant make stage-provision"
+    # Use a shell script that contains steps required to initialize a
+    # sandcats server.
+    main.vm.provision "shell", inline: "cd /vagrant && sudo apt-get update && sudo -u vagrant make stage-provision"
+  end
+
+  # If you're developing on Sandcats itself, you won't need to think
+  # about this "secondary" host. If you are hacking on config files
+  # etc. for the secondary DNS box, you will want to "vagrant up
+  # secondary" and "vagrant ssh secondary" to test it out.
+  #
+  # The way we configure it, at the moment, is via
+  # `secondary/Makefile` in the repository.
+  config.vm.define "secondary", primary: true do |secondary|
+    # Give this thing an IP address by which it can reach the main
+    # machine.
+    secondary.vm.network :private_network, ip: "169.254.253.3"
+
+    secondary.vm.provision "shell", inline: "cd /vagrant/secondary && sudo apt-get update && sudo -u vagrant MYSQL_PRIMARY_IP_ADDRESS=169.254.253.3 make stage-provision"
+  end
 end

--- a/conf/sandcats-replication.cnf
+++ b/conf/sandcats-replication.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+server-id=1
+binlog-format=mixed
+log-bin=mysql-bin
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1

--- a/secondary/Makefile
+++ b/secondary/Makefile
@@ -1,111 +1,116 @@
-# This is "some assembly required" probably.
+# To test the secondary DNS server, via its Vagrantfile, do:
 #
-# Before running this, you should add a line to /etc/hosts like
-#
-# master 10.0.0.3
-#
-# and configure autossh so that localhost port 6446 points at the
-# remote mysqld.
+# vagrant up secondary
+# vagrant reload secondary  # to get systemd as init system
+# vagrant ssh
+# cd /vagrant/secondary
+# make stage-after-authorize
+# make stage-start-secondary
 
-# The point of the Makefile is to get the following to be true for the
-# secondary DNS server.
-#
-# * MySQL is installed.
-#
-# * On system bootup, we SSH to master and get a My
-#
-#
-#
-
-# Steps:
-#
-#
-# On the primary, create a local user account called mysqlsecondary.
-#
-# On the secondary, look at MYSQL_PRIMARY_IP_ADDRESS environment
-# variable and add that into /etc/hosts.
-#
-# On the secondary, create a local user account called mysqlbridge and
-# do ssh-keygen -t rsa. Add ~/.ssh/id_rsa.pub to the mysqlsecondary
-# account on the primary.
-#
-# Set up autossh or inetd-based tunnel so that connecting to localhost
-# port 6446 results in a MySQL prompt. Sample test:
-#
-# echo 'select 1+1' | mysql -uslave -pslave 6446 | grep 2
-#
-# Install MySQL on the secondary. Accept Debian's defaults.
-#
-# Stop the MySQL service.
-#
-# On the primary, create a backup. Use innobackupex so that you get a
-# directory that you can tar up and scp over.
-#
-# Add /etc/mysql/my.cnf and /etc/mysql/debian.cnf to the files that
-# get backed up.
-#
-# Copy that to the secondary.
-#
-# Stop MySQL service.
-#
-# Copy the backed-up database etc. into /var
-#
-# Copy /etc/mysql/debian.cf into place.
-#
-# Modify /etc/mysql/my.cnf so that it has server-id=$(date +%s)
-#
-# idea from
-# http://www.semicomplete.com/blog/geekery/simple-mysql-slave-id-scaling.html
-#
-# On the primary, do GRANT REPLICATION SLAVE on *.* to
-# 'repl'@'127.0.0.1' IDENTIFIED BY 'pass';
-#
-# On the secondary, make sure you can
-
-#
-# 2. Copy the backed-up data to the secondary, and use its /var/lib/mysql.
-#
-# This also requires dealing with debian-sys-maint.
-#
-# sudo service mysql stop
-#
-#
-#
-# 3. Configure primary to allow replication from localhost. (We use
-# SSH for authorization/authentication.)
-#
-# 4. Copy the primary's /etc/mysql/my.cnf, but make server-id=2.
-#
-# 5.
-
-
-# TODO list:
+# TODO:
 #
 # * Make sure primary is actually using InnoDB.
 
-stage-before-authorize: stage-configure-hosts stage-configure-keypair
+stage-before-authorize: stage-configure-hosts stage-setup-mysql /usr/share/doc/systemd-sysv stage-configure-keypair
 
 stage-configure-hosts: /usr/share/doc/moreutils
+	# Let us configure our own hostname, for sysadmin convenience.
+	echo secondary | sudo dd of=/etc/hostname
+	echo '127.0.0.1 secondary' | sudo dd of=/etc/hosts conv=notrunc oflag=append
+	sudo hostname secondary
+
 	# Remove any lines that point to mysqlprimary.
 	grep -v mysqlprimary /etc/hosts | sudo sponge /etc/hosts
+
 	# Add the MySQL primary that someone just told us about.
 	echo $$MYSQL_PRIMARY_IP_ADDRESS mysqlprimary | sudo dd of=/etc/hosts conv=notrunc oflag=append
 
+stage-setup-mysql: /usr/share/doc/mysql-server /etc/mysql/conf.d/sandcats-replication-secondary.cnf
+
+/etc/mysql/conf.d/sandcats-replication-secondary.cnf: conf/sandcats-replication-secondary.cnf
+	# We take the config file snippet that we have, but we replace
+	# FIXME_CURRENT_DATE with the current UNIX timestamp. The goal
+	# is to get non-overlapping sever IDs for our secondary MySQL
+	# server(s).
+	#
+	# That tip courtesy of Jorden Sissel,
+	# http://www.semicomplete.com/blog/geekery/simple-mysql-slave-id-scaling.html
+	sudo service mysql stop
+	cat conf/sandcats-replication-secondary.cnf | sed 's,FIXME_CURRENT_DATE,'`date +%s`',' | sudo sponge /etc/mysql/conf.d/sandcats-replication-secondary.cnf
+	sudo service mysql start
+
 stage-configure-keypair: /home/mysqlbridge
 	# Create SSH keypair, if needed.
-	sudo -u mysqlbridge mkdir -m 0700 ~mysqlbridge/.ssh
 	sudo -u mysqlbridge bash -c '[ -f ~mysqlbridge/.ssh/id_rsa ] || ssh-keygen -t rsa -b 4096 -P "" -f ~mysqlbridge/.ssh/id_rsa'
 	# Show it.
-	sudo -u mysqlbridge cat ~mysqlbridge/.ssh/id_rsa.pub
+	sudo -u mysqlbridge cat ~mysqlbridge/.ssh/id_rsa.pub >&2
 
 /home/mysqlbridge:
 	# Create user.
 	sudo adduser --home /home/mysqlbridge --gecos 'MySQL Bridge' --disabled-password mysqlbridge
 
-stage-after-authorize: stage-configure-autossh
+stage-after-authorize: stage-verify-ssh stage-configure-autossh stage-get-mysql-backup
 
-stage-configure-autossh:
+# This is a separate Make target because it is so side-effect-y that I
+# want the admin to request it explicitly.
+stage-start-secondary: stage-load-mysql-backup
+	# OK, the scary part!
+	echo "START SLAVE;" | mysql -uroot
+
+stage-verify-ssh:
+	# Verify that SSH access works. This is actually an
+	# interactive process, since the user will have to say yes
+	# that they accept the SSH key.
 	sudo -u mysqlbridge ssh mysqlprimary echo success in logging in
+
+stage-configure-autossh: /usr/share/doc/autossh /etc/systemd/multi-user.target.wants.autossh.service
+
+/etc/systemd/multi-user.target.wants.autossh.service: /etc/systemd/system/autossh.service
+	# Doing this creates the symlink.
+	sudo systemctl enable autossh.service
+
+	# Doing this actually starts the service, which is important, too.
+	sudo systemctl start autossh.service
+
+/etc/systemd/system/autossh.service: conf/autossh.service
+	# Add an AutoSSH configuration so that, via a localhost port,
+	# we have an encrypted/authenticated/etc. way to reach the MySQL
+	# service on mysqlprimary.
+	sudo cp conf/autossh.service /etc/systemd/system/autossh.service
+	sudo chown root.root /etc/systemd/system/autossh.service
+	sudo systemctl daemon-reload
+
+stage-get-mysql-backup: /home/mysqlbridge/mysql-backup.sql
+
+/home/mysqlbridge/mysql-backup.sql: /usr/share/doc/mysql-client
+	# We would use sponge for atomic write, but since sponge keeps
+	# going even if the mysqldump process aborts in the
+	# middle... hmm well I guess this just isn't super robust if
+	# the process aborts in the middle for now. (What if it exits
+	# with a non-zero status code? What if the SSH tunnel breaks
+	# in the middle of the MySQL dump?)
+	mysqldump --host=127.0.0.1 --user=root --port=6446 --skip-lock-tables --single-transaction --flush-logs --hex-blob --master-data=1 -A  | sudo -u mysqlbridge sponge /home/mysqlbridge/mysql-backup.sql
+
+stage-load-mysql-backup: /usr/share/doc/mysql-server /home/mysqlbridge/mysql-backup.sql.loaded
+
+/home/mysqlbridge/mysql-backup.sql.loaded: /home/mysqlbridge/mysql-backup.sql
+	# Have to make sure MySQL is started.
+	sudo service mysql start
+
+	# Tell MySQL where to find the primary database. We do this
+	# now so that when we load the MySQL dump, the MySQL dump
+	# tells the database what the MASTER_LOG_FILE and
+	# MASTER_LOG_POS are. If we were to CHANGE MASTER to a new
+	# host/port *after* doing the backup import, it would mean
+	# that MySQL would throw away the MASTER_LOG_FILE &
+	# MASTER_LOG_POS value.
+	echo "CHANGE MASTER TO MASTER_HOST='127.0.0.1',MASTER_PORT=6446, MASTER_USER='replicator',MASTER_PASSWORD='replicator';" | mysql -uroot
+
+	# Time to load that backup into ourselves, via "mysql -uroot".
+	mysql -uroot < /home/mysqlbridge/mysql-backup.sql
+
+	# If that worked OK, let's touch a stamp file.
+	sudo -u mysqlbridge touch /home/mysqlbridge/mysql-backup.sql.loaded
 
 ### A tricky apt-get rule. The idea here is that other rules can
 ### depend on a package being installed on the system by depending on
@@ -113,4 +118,7 @@ stage-configure-autossh:
 ###
 ### If we need to install it, then we install it.
 /usr/share/doc/%:
-	sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y $(@F)
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install --quiet=2 -y $(@F)
+
+### Optional debugging tools.
+debug-tools: /usr/share/doc/telnet

--- a/secondary/Makefile
+++ b/secondary/Makefile
@@ -1,0 +1,116 @@
+# This is "some assembly required" probably.
+#
+# Before running this, you should add a line to /etc/hosts like
+#
+# master 10.0.0.3
+#
+# and configure autossh so that localhost port 6446 points at the
+# remote mysqld.
+
+# The point of the Makefile is to get the following to be true for the
+# secondary DNS server.
+#
+# * MySQL is installed.
+#
+# * On system bootup, we SSH to master and get a My
+#
+#
+#
+
+# Steps:
+#
+#
+# On the primary, create a local user account called mysqlsecondary.
+#
+# On the secondary, look at MYSQL_PRIMARY_IP_ADDRESS environment
+# variable and add that into /etc/hosts.
+#
+# On the secondary, create a local user account called mysqlbridge and
+# do ssh-keygen -t rsa. Add ~/.ssh/id_rsa.pub to the mysqlsecondary
+# account on the primary.
+#
+# Set up autossh or inetd-based tunnel so that connecting to localhost
+# port 6446 results in a MySQL prompt. Sample test:
+#
+# echo 'select 1+1' | mysql -uslave -pslave 6446 | grep 2
+#
+# Install MySQL on the secondary. Accept Debian's defaults.
+#
+# Stop the MySQL service.
+#
+# On the primary, create a backup. Use innobackupex so that you get a
+# directory that you can tar up and scp over.
+#
+# Add /etc/mysql/my.cnf and /etc/mysql/debian.cnf to the files that
+# get backed up.
+#
+# Copy that to the secondary.
+#
+# Stop MySQL service.
+#
+# Copy the backed-up database etc. into /var
+#
+# Copy /etc/mysql/debian.cf into place.
+#
+# Modify /etc/mysql/my.cnf so that it has server-id=$(date +%s)
+#
+# idea from
+# http://www.semicomplete.com/blog/geekery/simple-mysql-slave-id-scaling.html
+#
+# On the primary, do GRANT REPLICATION SLAVE on *.* to
+# 'repl'@'127.0.0.1' IDENTIFIED BY 'pass';
+#
+# On the secondary, make sure you can
+
+#
+# 2. Copy the backed-up data to the secondary, and use its /var/lib/mysql.
+#
+# This also requires dealing with debian-sys-maint.
+#
+# sudo service mysql stop
+#
+#
+#
+# 3. Configure primary to allow replication from localhost. (We use
+# SSH for authorization/authentication.)
+#
+# 4. Copy the primary's /etc/mysql/my.cnf, but make server-id=2.
+#
+# 5.
+
+
+# TODO list:
+#
+# * Make sure primary is actually using InnoDB.
+
+stage-before-authorize: stage-configure-hosts stage-configure-keypair
+
+stage-configure-hosts: /usr/share/doc/moreutils
+	# Remove any lines that point to mysqlprimary.
+	grep -v mysqlprimary /etc/hosts | sudo sponge /etc/hosts
+	# Add the MySQL primary that someone just told us about.
+	echo $$MYSQL_PRIMARY_IP_ADDRESS mysqlprimary | sudo dd of=/etc/hosts conv=notrunc oflag=append
+
+stage-configure-keypair: /home/mysqlbridge
+	# Create SSH keypair, if needed.
+	sudo -u mysqlbridge mkdir -m 0700 ~mysqlbridge/.ssh
+	sudo -u mysqlbridge bash -c '[ -f ~mysqlbridge/.ssh/id_rsa ] || ssh-keygen -t rsa -b 4096 -P "" -f ~mysqlbridge/.ssh/id_rsa'
+	# Show it.
+	sudo -u mysqlbridge cat ~mysqlbridge/.ssh/id_rsa.pub
+
+/home/mysqlbridge:
+	# Create user.
+	sudo adduser --home /home/mysqlbridge --gecos 'MySQL Bridge' --disabled-password mysqlbridge
+
+stage-after-authorize: stage-configure-autossh
+
+stage-configure-autossh:
+	sudo -u mysqlbridge ssh mysqlprimary echo success in logging in
+
+### A tricky apt-get rule. The idea here is that other rules can
+### depend on a package being installed on the system by depending on
+### the filesystem-path of /usr/share/doc/$packagename.
+###
+### If we need to install it, then we install it.
+/usr/share/doc/%:
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y $(@F)

--- a/secondary/conf/autossh.service
+++ b/secondary/conf/autossh.service
@@ -1,0 +1,11 @@
+[Service]
+User=mysqlbridge
+Group=mysqlbridge
+WorkingDirectory=/home/mysqlbridge
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=autossh-mysql
+ExecStart=/usr/bin/autossh -C mysqlprimary -N -L 6446:localhost:3306
+
+[Install]
+WantedBy=multi-user.target

--- a/secondary/conf/sandcats-replication-secondary.cnf
+++ b/secondary/conf/sandcats-replication-secondary.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+server-id=FIXME_CURRENT_DATE


### PR DESCRIPTION
This commit series adds the ability to run a secondary DNS server, driven almost entirely by Make and/or Vagrant. (The idea is that we test & develop the Makefile, and use the Makefile in production.)

If it passes the tests, I'll merge it.

The one thing I haven't done yet is configure PowerDNS on the secondary. The other thing I haven't done is to write tests for this yet. The other thing I haven't done is integrate tests for the secondary _dns service_ into the test suite for the app as a whole.
