### PR TITLE
Store NS1_IP_ADDRESS in config file

### DIFF
--- a/conf/sample-meteor-settings.json
+++ b/conf/sample-meteor-settings.json
@@ -1,5 +1,6 @@
 {"NS1_HOSTNAME": "ns1.sandcatz.io",
  "NS2_HOSTNAME": "ns2.sandcatz.io",
+ "NS1_IP_ADDRESS": "127.0.0.1",
  "BASE_DOMAIN": "sandcatz.io",
  "POWERDNS_USER": "sandcats_pdns",
  "POWERDNS_DB": "sandcats_pdns",

--- a/sandcats/lib/dns.js
+++ b/sandcats/lib/dns.js
@@ -80,7 +80,7 @@ function createDomain(mysqlQuery, domain) {
 
   console.log("Created domain; it received ID #" + result.insertId);
   console.log("Creating records for top level...");
-  createRecord(mysqlQuery, Meteor.settings.BASE_DOMAIN, Meteor.settings.BASE_DOMAIN, 'A', '127.0.0.1');
+  createRecord(mysqlQuery, Meteor.settings.BASE_DOMAIN, Meteor.settings.BASE_DOMAIN, 'A', Meteor.settings.NS1_IP_ADDRESS);
   createRecord(mysqlQuery, Meteor.settings.BASE_DOMAIN, Meteor.settings.BASE_DOMAIN, 'SOA', formatSoaRecord(
     // The SOA advertises the first nameserver.
     Meteor.settings.NS1_HOSTNAME,

--- a/sandcats/lib/settings.js
+++ b/sandcats/lib/settings.js
@@ -23,6 +23,12 @@ var settingsSchema = new SimpleSchema({
     type: String
   },
 
+  // IP address of first nameserver for the domain, which is also used
+  // as IP address for the apex of the domain.
+  NS1_IP_ADDRESS: {
+    type: String
+  },
+
   // Username for connecting to MySQL for PowerDNS.
   POWERDNS_USER: {
     type: String


### PR DESCRIPTION
This is easier and more portable than programmatically asking
Google Compute Engine (or checkip.dyndns.org etc.) what our IP address is
at the moment.

Close #2
