### PR TITLE
Make front page redirect to wiki

### DIFF
--- a/sandcats/sandcats.js
+++ b/sandcats/sandcats.js
@@ -16,9 +16,16 @@ if (Meteor.isServer) {
 // HTTP API-type URL handling.
 
 Router.map(function() {
-  // Provide a trivial front page, to avoid the Iron Router default.
+  // Redirect the front page to the Sandstorm wiki.
   this.route('root', {
-    path: '/'
+    path: '/',
+    where: 'server',
+    action: function() {
+      this.response.writeHead(302, {
+        'Location': 'https://github.com/sandstorm-io/sandstorm/wiki/Sandcats-dynamic-DNS'
+      });
+      this.response.end();
+    }
   });
 
   this.route('register', {


### PR DESCRIPTION
This way, if people try to go to the front page, they'll see some useful info.

It's a 302 not a 301 because who knows, maybe some day we'll want to put some actual info on the front page.
