### PR TITLE
Allow a Sandcats server to support prod & dev GlobalSign APIs

### DIFF
--- a/conf/sample-meteor-settings.json
+++ b/conf/sample-meteor-settings.json
@@ -7,5 +7,8 @@
  "POWERDNS_PASSWORD": "3Rb4k4BQqKr59Ewj",
  "UDP_PING_PORT": 8080,
  "ROOT_URL": "https://sandcats.io/",
- "EMAIL_FROM_ADDRESS": "noreply-sandcats-example@example.com"
+ "EMAIL_FROM_ADDRESS": "noreply-sandcats-example@example.com",
+ "GLOBALSIGN_DEV_HOSTNAMES": ["devver1", "devver2"],
+ "GLOBALSIGN_PROD_HOSTNAMES": ["prodder1"],
+ "GLOBALSIGN_DEFAULT": "dev"
 }

--- a/sandcats/lib/globalsign.js
+++ b/sandcats/lib/globalsign.js
@@ -4,8 +4,8 @@ var globalsignWsdls = {
   'prod': null  // for now.
 };
 
-// We use _client to cache a working SOAP client to the particular
-// GlobalSign API endpoint we need.
+// We use _clients to cache working SOAP client to the various
+// GlobalSign API endpoints we need.
 //
 // Do not access it directly. Access it via getClient() so it can be
 // created if needed.
@@ -79,8 +79,10 @@ getMsslDomainInfo = function(domain, devOrProd) {
   return usefulResult;
 }
 
-// Like _client, _myDomainInfo caches information to avoid unnecessary
-// fetching. Don't access _myDomainInfo directly; access it via
+// Like _clients, _myDomainInfo caches information to avoid
+// unnecessary fetching. Also like _clients this variable contains
+// data from the GlobalSign prod API as well as from the GlobalSign
+// dev API. Don't access _myDomainInfo directly; access it via
 // getMyDomainInfo().
 var _myDomainInfo = {};
 getMyDomainInfo = function(devOrProd) {

--- a/sandcats/lib/globalsign.js
+++ b/sandcats/lib/globalsign.js
@@ -9,28 +9,46 @@ var globalsignWsdls = {
 //
 // Do not access it directly. Access it via getClient() so it can be
 // created if needed.
-var _client = null;
-function getClient() {
-  if (! Meteor.settings.GLOBALSIGN_USERNAME) {
-    throw new Error("Cannot construct client since we have no username configured.");
+var _clients = {};
+getDevOrProdByHostname = function(hostname) {
+  if (_.contains(Meteor.settings.GLOBALSIGN_DEV_HOSTNAMES, hostname)) {
+    return 'dev';
   }
+  if (_.contains(Meteor.settings.GLOBALSIGN_PROD_HOSTNAMES, hostname)) {
+    return 'prod';
+  }
+  return Meteor.settings.GLOBALSIGN_DEFAULT;
+}
 
+function getUsername(devOrProd) {
+  var usernameKey = {'dev': 'GLOBALSIGN_DEV_USERNAME',
+                     'prod': 'GLOBALSIGN_PROD_USERNAME'}[devOrProd];
+  return Meteor.settings[usernameKey];
+}
+
+function getPassword(devOrProd) {
+  var passwordKey = {'dev': 'GLOBALSIGN_DEV_PASSWORD',
+                     'prod': 'GLOBALSIGN_PROD_PASSWORD'}[devOrProd];
+  return process.env[passwordKey];
+}
+
+function getClient(devOrProd) {
   if (! Meteor.settings.GLOBALSIGN_DOMAIN) {
     throw new Error("Cannot construct client since we have no domain configured.");
   }
 
-  if (! Meteor.settings.GLOBALSIGN_DEV_OR_PROD) {
-    throw new Error("Cannot construct client since we don't know if dev or prod.");
+  if (! getUsername(devOrProd)) {
+    throw new Error("Cannot construct client since we have no username configured.");
   }
 
-  if (! process.env.GLOBALSIGN_PASSWORD) {
+  if (! getPassword(devOrProd)) {
     throw new Error("Cannot construct client since we have no password available.");
   }
 
-  if (! _client) {
-    _client = Meteor.wrapAsync(soap.createClient)(globalsignWsdls[Meteor.settings.GLOBALSIGN_DEV_OR_PROD]);
+  if (! _clients[devOrProd]) {
+    _clients[devOrProd] = Meteor.wrapAsync(soap.createClient)(globalsignWsdls[devOrProd]);
   }
-  return _client;
+  return _clients[devOrProd];
 }
 
 // For custom certificate validity, GlobalSign's API wants us to
@@ -38,14 +56,14 @@ function getClient() {
 var DUMMY_MONTHS_VALUE = 6;
 
 // Use this function to get information about a domain.
-getMsslDomainInfo = function(domain) {
-  var wrapped = Meteor.wrapAsync(getClient().GetMSSLDomains);
+getMsslDomainInfo = function(domain, devOrProd) {
+  var wrapped = Meteor.wrapAsync(getClient(devOrProd).GetMSSLDomains);
   var args = {
     'Request': {
       'QueryRequestHeader': {
         'AuthToken': {
-          'UserName': Meteor.settings.GLOBALSIGN_USERNAME,
-          'Password': process.env.GLOBALSIGN_PASSWORD
+          'UserName': getUsername(devOrProd),
+          'Password': getPassword(devOrProd)
         }}}};
   var result = wrapped(args);
   var usefulResult = {};
@@ -64,12 +82,12 @@ getMsslDomainInfo = function(domain) {
 // Like _client, _myDomainInfo caches information to avoid unnecessary
 // fetching. Don't access _myDomainInfo directly; access it via
 // getMyDomainInfo().
-var _myDomainInfo;
-getMyDomainInfo = function() {
-  if (! _myDomainInfo) {
-    _myDomainInfo = getMsslDomainInfo(Meteor.settings.GLOBALSIGN_DOMAIN);
+var _myDomainInfo = {};
+getMyDomainInfo = function(devOrProd) {
+  if (! _myDomainInfo[devOrProd]) {
+    _myDomainInfo[devOrProd] = getMsslDomainInfo(Meteor.settings.GLOBALSIGN_DOMAIN, devOrProd);
   }
-  return _myDomainInfo;
+  return _myDomainInfo[devOrProd];
 }
 
 // This function generates the list of arguments we provide to PVOrder
@@ -131,14 +149,14 @@ getOrderRequestParameter = function(csrText, now) {
 // PVOrder, including the AuthToken in the
 // OrderRequestHeader. Therefore it does require secrets and can't
 // be as easily unit-tested.
-getAllSignCsrArgs = function(domainInfo, csrText) {
+getAllSignCsrArgs = function(domainInfo, csrText, devOrProd) {
   var args = {
     'MSSLDomainID': domainInfo.MSSLDomainID,
     'MSSLProfileID': domainInfo.MSSLProfileID,
     'OrderRequestHeader': {
       'AuthToken': {
-        'UserName': Meteor.settings.GLOBALSIGN_USERNAME,
-        'Password': process.env.GLOBALSIGN_PASSWORD
+        'UserName': getUsername(devOrProd),
+        'Password': getPassword(devOrProd)
       }
     },
     // Note: ContactInfo is ignored by GlobalSign in the ManagedSSL
@@ -155,10 +173,10 @@ getAllSignCsrArgs = function(domainInfo, csrText) {
   return finalArgs;
 };
 
-issueCertificate = function(csrText) {
+issueCertificate = function(csrText, devOrProd) {
   var domainInfo = getMyDomainInfo();
   var args = getAllSignCsrArgs(domainInfo, csrText);
-  var wrapped = Meteor.wrapAsync(getClient().PVOrder);
+  var wrapped = Meteor.wrapAsync(getClient(devOrProd).PVOrder);
   var globalsignResponse = wrapped(args);
   if (globalsignResponse.Response.OrderResponseHeader.SuccessCode == -1) {
     console.log(JSON.stringify(globalsignResponse.Response.OrderResponseHeader.Errors));

--- a/sandcats/lib/settings.js
+++ b/sandcats/lib/settings.js
@@ -104,8 +104,9 @@ var settingsSchema = new SimpleSchema({
   // API calls to GlobalSign can use their testing API ("dev") or
   // their live API ("prod"). This specifies the default.
   //
-  // It is optional. If it is not set at all, then we do not use
-  // the GlobalSign API for domains not whitelisted above.
+  // It is safe to set this to "dev" even if you don't want GlobalSign
+  // integration to work on your particular Sandcats install. It may
+  // result in some runtime exceptions, but nothing too bad.
   GLOBALSIGN_DEFAULT: {
     type: String,
     allowedValues: ["dev", "prod"]

--- a/sandcats/lib/settings.js
+++ b/sandcats/lib/settings.js
@@ -66,7 +66,14 @@ var settingsSchema = new SimpleSchema({
   // and password. The username is not a secret; the password is. It
   // is permissible to run this code without the GlobalSign username
   // configured.
-  GLOBALSIGN_USERNAME: {
+  //
+  // This setting occurs in both DEV_ and PROD_ form.
+  GLOBALSIGN_DEV_USERNAME: {
+    type: String,
+    optional: true
+  },
+
+  GLOBALSIGN_PROD_USERNAME: {
     type: String,
     optional: true
   },
@@ -80,11 +87,27 @@ var settingsSchema = new SimpleSchema({
     optional: true
   },
 
+  // A list of hostnames that will always use the GlobalSign dev API.
+  // These hostnames can use always use the GlobalSign dev API to get
+  // certificates.
+  GLOBALSIGN_DEV_HOSTNAMES: {
+    type: [String]
+  },
+
+  // A list of hostnames that will always use the GlobalSign
+  // production API. They can use the production GlobalSign API no
+  // matter if dev or prod is the default.
+  GLOBALSIGN_PROD_HOSTNAMES: {
+    type: [String]
+  },
+
   // API calls to GlobalSign can use their testing API ("dev") or
-  // their live API ("prod").
-  GLOBALSIGN_DEV_OR_PROD: {
-    type: String,
-    optional: true
+  // their live API ("prod"). This specifies the default.
+  //
+  // It is optional. If it is not set at all, then we do not use
+  // the GlobalSign API for domains not whitelisted above.
+  GLOBALSIGN_DEFAULT: {
+    type: String
   }
 });
 

--- a/sandcats/lib/settings.js
+++ b/sandcats/lib/settings.js
@@ -107,7 +107,8 @@ var settingsSchema = new SimpleSchema({
   // It is optional. If it is not set at all, then we do not use
   // the GlobalSign API for domains not whitelisted above.
   GLOBALSIGN_DEFAULT: {
-    type: String
+    type: String,
+    allowedValues: ["dev", "prod"]
   }
 });
 

--- a/sandcats/sandcats.js
+++ b/sandcats/sandcats.js
@@ -70,11 +70,7 @@ Router.map(function() {
     path: '/getcertificate',
     where: 'server',
     action: function() {
-      /* When doGetCertificate() is ready, uncomment this.
-
       doGetCertificate(this.request, this.response);
-
-      */
     }
   });
 });

--- a/sandcats/server/register.js
+++ b/sandcats/server/register.js
@@ -445,7 +445,8 @@ function doGetCertificate(request, response) {
 
   // Send the request to GlobalSign. Note that this seems to take
   // about 30 seconds.
-  var globalsignResponse = issueCertificate(validatedFormData.certificateSigningRequest);
+  var devOrProd = getDevOrProdByHostname(validatedFormData.rawHostname);
+  var globalsignResponse = issueCertificate(validatedFormData.certificateSigningRequest, devOrProd);
 
   // Pass the result to a helper function we can unit-test.
   return finishGlobalsignResponse(globalsignResponse, response);

--- a/sandcats/tests/jasmine/server/integration/RegisterSpec.js
+++ b/sandcats/tests/jasmine/server/integration/RegisterSpec.js
@@ -26,6 +26,23 @@ Jasmine.onTest(function () {
       });
     }
 
+    describe('useCorrectGlobalSignApi', function() {
+      it('should return dev for devver1', function() {
+        var x = getDevOrProdByHostname("devver1");
+        expect(x).toBe("dev");
+      });
+
+      it('should return prod for prodder1', function() {
+        var x = getDevOrProdByHostname("prodder1");
+        expect(x).toBe("prod");
+      });
+
+      it('should return dev by default', function() {
+        var x = getDevOrProdByHostname("someone-else");
+        expect(x).toBe("dev");
+      });
+    });
+
     describe('registerActionSignsCsr', function() {
       afterEach(function () {
         // This removes all data from the database that we insert as part of


### PR DESCRIPTION
It uses Meteor settings to decide which domains to send to which APIs.

Close #81
