### PR TITLE
Make doGetCertificate public

### DIFF
--- a/sandcats/server/register.js
+++ b/sandcats/server/register.js
@@ -408,7 +408,7 @@ doUpdate = function(request, response) {
   }
 };
 
-function doGetCertificate(request, response) {
+doGetCertificate = function(request, response) {
   var requestEnded = antiCsrf(request, response);
   if (requestEnded) {
     return;


### PR DESCRIPTION
This way /getcertificate can do something other can crash
