### PR TITLE
Start sandcats service after MySQL is ready

### DIFF
--- a/conf/sandcats.service
+++ b/conf/sandcats.service
@@ -1,3 +1,7 @@
+[Unit]
+Description=Sandcats Meteor+Node code
+After=mysql.service
+
 [Service]
 User=vagrant
 Group=vagrant


### PR DESCRIPTION
If this had been in place, I could avoided a (brief) outage (that didn't affect any users).
