### PR TITLE
Use endsWith from underscorejs

### DIFF
--- a/sandcats/lib/validation.js
+++ b/sandcats/lib/validation.js
@@ -62,7 +62,7 @@ function commonNameMatchesHostname(csr, rawHostname) {
   var baseDomainWithDot = "." + Meteor.settings.BASE_DOMAIN;
 
   // Verify that the hostname ends in our BASE_DOMAIN
-  if (! commonNameFromCsr.endsWith(baseDomainWithDot)) {
+  if (! _.endsWith(commonNameFromCsr, baseDomainWithDot)) {
     return false;
   }
 


### PR DESCRIPTION
It seems String.prototype.endsWith is not available in production. I do not
particularly know why, but underscorejs can save us.
