### PR TITLE
If sandcats service crashes, restart it

### DIFF
--- a/conf/sandcats.service
+++ b/conf/sandcats.service
@@ -12,6 +12,7 @@ SyslogIdentifier=sandcats-meteor
 Environment=PORT=3000 MONGO_URL=mongodb://localhost/sandcats_mongo ROOT_URL=http://localhost/
 EnvironmentFile=-/etc/sandcats.environ
 ExecStart=/bin/bash -c 'METEOR_SETTINGS="$(cat /etc/sandcats-meteor-settings.json)" /usr/local/bin/node main.js'
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Back-story:
- There have been (I believe) 3 outages in the past week for the Sandcats service. Some of them have lasted more than hour because they occurred while I was asleep and my phone was in "airplane mode" for sleep (which is how I normally "silence" notifications).
- The outages take the form, "A server-side route raised an unhandled exception because we did not get data from GlobalSign's SOAP API in the format we expected."
- There are few different sub-problems here, it seems to me:
  - The sandcats service, upon failure, does not auto-restart.
  - Service notifications do not always reach me in a timely fashion.
  - server-side routes can crash the entire nodejs/meteor process if they hit an unhandled exception.

This commit only fixes the first of these issues. But it's worth fixing, I believe.

Also, hey @zarvox, systemd is pretty cool.
