### PR TITLE
Switch Vagrantfile to be based on Sandstorm base box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base ourselves on a reasonable-seeming Debian base box. Jessie so
   # we can have systemd.
-  config.vm.box = "debian/jessie64"
+  config.vm.box = "sandstorm/debian-jessie64"
 
   # Avoid 'stdin is not a tty' pseudo-error.
   config.ssh.pty = true


### PR DESCRIPTION
Rationale: The Debian base box disabled support (perhaps temporarily)
for vboxsf file sharing, but I like VirtualBox's file sharing.
