### PR TITLE
Add implementation and tests for reserving a domain name

### DIFF
--- a/sandcats/lib/collections.js
+++ b/sandcats/lib/collections.js
@@ -14,7 +14,7 @@ var recoveryTokenSchema = new SimpleSchema({
     max: 40
   },
   timestamp: {
-    // Rely in Javascript+Mongo+etc. to avoid timezone problems, since
+    // Rely on Javascript+Mongo+etc. to avoid timezone problems, since
     // in JS, date objects are timezone-aware by default.
     type: Date
   }
@@ -44,12 +44,30 @@ UserRegistrations.attachSchema(new SimpleSchema({
     // validate that this is actually an email address.
     type: String
   },
+}));
+
+// We have a separate collection for reserved domain names, rather
+// than storing them in UserRegistrations somehow. This is because:
+//
+// 1. https://blog.engineyard.com/2011/5-subtle-ways-youre-using-mysql-as-a-queue-and-why-itll-bite-you/
+//
+// 2. It makes the logic simpler. This way, I don't have to create a
+//    special fake value for the required publicKeyId parameter, etc.
+
+DomainReservations = new Mongo.Collection("domainReservations");
+DomainReservations.attachSchema(new SimpleSchema({
+  hostname: hostnameType,
+  emailAddress: {
+    // We use a string here for convenience. We rely on Mesosphere to
+    // validate that this is actually an email address.
+    type: String
+  },
   recoveryData: {
-    // If there is an object here, then we allow the use of the
-    // .recoveryData.recoveryToken as a string which can be used
-    // to set the domain to a new public key.
-    type: recoveryTokenSchema,
-    optional: true
+    // Reserved domains MUST have recoveryData. We call this a domain
+    // reservation code publicly since the purpose is to create a
+    // domain for the first time. As an implementation detail, it is
+    // the same as a recovery token.
+    type: recoveryTokenSchema
   }
 }));
 

--- a/sandcats/sandcats.js
+++ b/sandcats/sandcats.js
@@ -42,6 +42,22 @@ Router.map(function() {
     }
   });
 
+  this.route('reserve', {
+    path: '/reserve',
+    where: 'server',
+    action: function() {
+      doReserve(this.request, this.response);
+    }
+  });
+
+  this.route('registerreserved', {
+    path: '/registerreserved',
+    where: 'server',
+    action: function() {
+      doRegisterReserved(this.request, this.response);
+    }
+  });
+
   this.route('sendrecoverytoken', {
     path: '/sendrecoverytoken',
     where: 'server',

--- a/sandcats/server/register.js
+++ b/sandcats/server/register.js
@@ -1,4 +1,4 @@
-function finishResponse(status, jsonData, response, plainTextOnly) {
+finishResponse = function(status, jsonData, response, plainTextOnly) {
   if (plainTextOnly) {
     // If the client really really wants plain text, then we hope that
     // the jsonData object has a 'text' property.
@@ -21,7 +21,7 @@ function finishResponse(status, jsonData, response, plainTextOnly) {
   response.end(JSON.stringify(jsonData));
 }
 
-function responseFromFormFailure(validatedFormData) {
+responseFromFormFailure = function(validatedFormData) {
   var response = {error: validatedFormData.errors};
 
   // The response['text'] is information that we show to a person
@@ -57,7 +57,7 @@ function responseFromFormFailure(validatedFormData) {
   return response;
 }
 
-function antiCsrf(request, response) {
+antiCsrf = function(request, response) {
   // Two mini anti-cross-site request forgery checks: POST and a
   // custom HTTP header.
   var requestEnded = false;
@@ -72,7 +72,7 @@ function antiCsrf(request, response) {
   return requestEnded;
 }
 
-function getFormDataFromRequest(request) {
+getFormDataFromRequest = function(request) {
   // The form data is the request body, plus some extra data that we
   // add as if the user submitted it, for convenience of our own
   // processing.
@@ -89,7 +89,7 @@ function getFormDataFromRequest(request) {
   return rawFormData;
 }
 
-function getClientIpFromRequest(request) {
+getClientIpFromRequest = function(request) {
   // The X-Real-IP header contains the client's IP address, and since
   // it's a non-standard header, the Meteor built-in proxy does not
   // mess with it. We assume nginx is going to give this to us.
@@ -97,7 +97,7 @@ function getClientIpFromRequest(request) {
   return clientIp || "";
 }
 
-function wantsPlainText(request) {
+wantsPlainText = function(request) {
   // If the HTTP client can only handle a text/plain response, the
   // Sandcats code honors that by throwing away everything but the
   // 'text' key in the object we were going to respond with.
@@ -137,7 +137,7 @@ doRegister = function(request, response) {
 
   // Give the user an indication of our success.
   return finishResponse(200, {
-    'success': true, 'text': "Successfully registered!"
+    'success': true, 'text': "Successfully registered!",
   }, response, plainTextOnly);
 }
 
@@ -304,7 +304,7 @@ doRecover = function(request, response) {
   }
 }
 
-function createUserRegistration(formData) {
+createUserRegistration = function(formData) {
   // To create a user registration, we mostly copy data from the form.
   // We do also need to store a public key "fingerprint", which for
   // now we calculated as deadbeaf.
@@ -330,6 +330,15 @@ function createUserRegistration(formData) {
     mysqlQuery,
     userRegistration.hostname,
     userRegistration.ipAddress);
+
+  return recoveryToken;
+}
+
+generateRecoveryData = function() {
+  var recoveryData = {}
+  recoveryData.recoveryToken = Random.id(40);
+  recoveryData.timestamp = new Date();
+  return recoveryData;
 }
 
 function addRecoveryData(formData) {
@@ -340,9 +349,7 @@ function addRecoveryData(formData) {
   // as we can send them a token by email.
 
   // Generate some recovery data.
-  var recoveryData = {}
-  recoveryData.recoveryToken = Random.id(40);
-  recoveryData.timestamp = new Date();
+  var recoveryData = generateRecoveryData();
 
   // Always just toss it onto the corresponding UserRegistration
   // record. (We will only send the recoveryToken to email address

--- a/sandcats/server/reservedomain.js
+++ b/sandcats/server/reservedomain.js
@@ -1,0 +1,259 @@
+// This file contains the functions that handle tasks related to reserving domain names with a
+// token.
+
+// Create a form validation rule for checking if a hostname is reserved. This gets used by the
+// /register HTTPS RPC method as well as /reserve.
+Mesosphere.registerRule('hostnameNotReserved', function (fieldValue, ruleValue) {
+  if (! ruleValue) {
+    // if the user includes us but sets the validation to false,
+    // they don't need us to validate.
+    return true;
+  }
+
+  // If the hostname is pre-reserved, then block this registration.
+  var reservationExists = (DomainReservations.find({hostname: fieldValue}).count() > 0);
+  if (reservationExists) {
+    return false;
+  }
+
+  // I guess it is OK!
+  return true;
+});
+
+// Create validator for getting a domain reservation token.
+Mesosphere({
+  name: 'reserveForm',
+  fields: {
+    rawHostname: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      transforms: ["clean", "toLowerCase"],
+      rules: {
+        minLength: 1,
+        maxLength: 20,
+        hostnameUnused: true,
+        hostnameNotReserved: true,
+        extraHyphenRegexes: true,
+      }
+    },
+    email: {
+      required: true,
+      format: "email"
+    }
+  },
+  aggregates: {
+    updateIsAuthorized: ['hostnameAndPubkeyMatch', ['rawHostname', 'pubkey']]
+  }
+});
+
+// Create validator for turning a domainReservationToken into a registered domain.
+//
+// If a user gives us a valid form like this, we create a domain on their behalf. We need less info
+// in this, compared to registerForm, because the personal info was already submitted as part of
+// reserving the domain name.
+Mesosphere({
+  name: 'reservedDomainRegisterForm',
+  fields: {
+    domainReservationToken: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      rules: {
+        minLength: 40,
+        maxLength: 40
+      },
+    },
+    rawHostname: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      transforms: ["clean", "toLowerCase"],
+      rules: {
+        minLength: 1,
+        maxLength: 20,
+        hostnameUnused: true
+      }
+    },
+    pubkey: {
+      required: true,
+      rules: {
+        minLength: 40,
+        maxLength: 40,
+        keyFingerprintUnique: true
+      },
+    }
+  },
+  aggregates: {
+    domainReservationTokenUseIsAuthorized: ['domainReservationTokenUseIsAuthorized',
+                                             ['rawHostname', 'domainReservationToken']]
+  }
+});
+
+// Give the user half an hour to use this token. They had better hurry.
+var MAX_STALENESS_IN_SECONDS = 30 * 60;
+var domainReservationTokenHasAcceptableStaleness = makeTokenExpirationChecker(
+  MAX_STALENESS_IN_SECONDS);
+
+
+Mesosphere.registerAggregate('domainReservationTokenUseIsAuthorized', function(fields, formFieldsObject) {
+  // Using a domain registration token is authorized under the following circumstances.
+  //
+  // - The domain in question has an entry in DomainReservations.
+  //
+  // - The object has a recoveryData attribute.
+  //
+  // - The recoveryData's timestamp is less than RECOVERY_TIME_PERIOD_IN_SECONDS old.
+  //
+  // - The recoveryToken we are given is the same as the one in the recoveryData.
+  var datum = DomainReservations.findOne({'hostname': formFieldsObject.rawHostname});
+
+  if (! datum) {
+    return false;
+  }
+
+  var recoveryData = datum.recoveryData;
+  if (! recoveryData) {
+    return false;
+  }
+
+  if (! domainReservationTokenHasAcceptableStaleness(recoveryData)) {
+    return false;
+  }
+
+  if (formFieldsObject.domainReservationToken == recoveryData.recoveryToken) {
+    return true;  // hooray!
+  }
+
+  return false;
+});
+
+// HTTP response functions, aka "views".
+
+doRegisterReserved = function(request, response) {
+  // This gets called via install.sh, when someone wants to actually register a domain they've
+  // reserved.
+  //
+  // - Client submits a form that is basically the same as recover, but using a
+  //   domainReservationToken.
+  //
+  // - We create their domain for them.
+  console.log("Beginning registration of reserved domain.");
+
+  var requestEnded = antiCsrf(request, response);
+  if (requestEnded) {
+    return;
+  }
+
+  var rawFormData = getFormDataFromRequest(request);
+  var plainTextOnly = wantsPlainText(request);
+
+  var validatedFormData = Mesosphere.reservedDomainRegisterForm.validate(rawFormData);
+  if (validatedFormData.errors) {
+    return finishResponse(400,
+                          responseFromFormFailure(validatedFormData),
+                          response,
+                          plainTextOnly);
+  }
+  if (! validatedFormData.formData.domainReservationTokenUseIsAuthorized) {
+    return finishResponse(400, {
+      'text':
+      'Bad domainReservationToken. If you are an end user, contact your Sandstorm hosting provider.'
+    }, response, plainTextOnly);
+  }
+
+  // Great! It passed all our validation. Enrich the submitted form with information
+  // from DomainReservations.
+  var reservation = DomainReservations.findOne({
+    "recoveryData.recoveryToken": validatedFormData.formData.domainReservationToken,
+    "hostname": validatedFormData.formData.rawHostname,
+  });
+  if (! reservation) {
+    console.log("*** ERROR ***: Ran into a mis-hap while attempting to register reserved domain.");
+    console.log("Form submission:", JSON.stringify(validatedFormData));
+    return finishResponse(500, {
+      'text': 'Server error E101. Please email support@sandstorm.io to get help.'
+    }, response, plainTextOnly);
+  }
+
+  var userRegistration = {
+    rawHostname: validatedFormData.formData.rawHostname,
+    ipAddress: validatedFormData.formData.ipAddress,
+    pubkey: validatedFormData.formData.pubkey,
+    email: reservation.emailAddress,
+  };
+
+  createUserRegistration(userRegistration);
+
+  // Now that we've registered them, destroy the reservation.
+  DomainReservations.remove({_id: reservation._id});
+
+  // Give the user an indication of our success.
+  return finishResponse(200, {
+    'success': true, 'text': "Successfully registered!",
+  }, response, plainTextOnly);
+
+}
+
+
+doReserve = function(request, response) {
+  // Reserving a domain name is where you give us a name+email address for a domain, and get a
+  // recoveryToken back (which we call a domainReservationToken). We don't create a real
+  // UserRegistration and we don't store any client cert.
+  //
+  // Everyone is allowed to reserve a domain. This creates a DomainReservations document whose
+  // recoveryToken data hints at a timestamp.
+  //
+  // In the future, we might:
+  //
+  // - Limit which IP addresses can use this API
+  //
+  // - Ask people to register with us before using it
+  //
+  // But for now, enjoy the free-for-all.
+  console.log("Beginning domain reservation process.");
+
+  // Unlike other service endpoints, doReserve is allowed to be accessed via a browser. So we skip
+  // the check for the ability to send a custom header. We do still check that this is a POST.
+  if (request.method != 'POST') {
+    return;
+  }
+
+  // The purpose of this endpoint is to generate a token that is consumed by Javascript operating on
+  // an arbitrary origin. So allow it.
+  response.setHeader('Access-Control-Allow-Origin', '*');
+
+  // By the way, you might wonder - won't browsers attempt to submit a client certificate if they
+  // have one? The answer is "No, so long as {withCredentials: false} is part of the XMLHttpRequest
+  // invocation."
+
+  var plainTextOnly = false;
+  var rawFormData = getFormDataFromRequest(request);
+  var validatedFormData = Mesosphere.reserveForm.validate(rawFormData);
+  if (validatedFormData.errors) {
+    return finishResponse(400,
+                          responseFromFormFailure(validatedFormData),
+                          response,
+                          plainTextOnly);
+  }
+
+  // Great! It passed all our validation. Let's reserve the domain.
+  var recoveryToken = createDomainReservation(validatedFormData.formData);
+
+  // Give the user an indication of our success.
+  return finishResponse(200, {
+    'success': true, 'text': "Successfully registered!",
+    'token': recoveryToken,
+  }, response, plainTextOnly);
+}
+
+
+
+// Functions to actually store data in the database.
+function createDomainReservation(formData) {
+  console.log("Reserving domain with data", JSON.stringify(formData));
+  var recoveryData = generateRecoveryData();
+  var domainReservationId = DomainReservations.insert({
+    hostname: formData.rawHostname,
+    emailAddress: formData.email,
+    recoveryData: recoveryData
+  });
+  return recoveryData.recoveryToken;
+}


### PR DESCRIPTION
Details:
- Create two new HTTP API methods, /reserve and /registerreserved
- Create a new Mongo collection for DomainReservations
- Adjust registration flow to block registering reserved domains
- Add tests for /reserve to make sure you cannot reserve domains that
  are already in use, and that an email address is required, as well
  as testing the successful /reserve => /registerreserved flow
