### PR TITLE
Add implementation and tests for reserving a domain name

### DIFF
--- a/sandcats/integration_tests.py
+++ b/sandcats/integration_tests.py
@@ -144,12 +144,16 @@ def _add_real_client_cert(n, requests_kwargs):
 def _make_api_call(rawHostname, key_number, path='register',
                    provide_x_sandcats=True, external_ip=False,
                    http_method='post', accept_mime_type=None,
+                   domainReservationToken=None,
                    email='benb@benb.org', recoveryToken=None,
                    x_forwarded_for=None):
     '''This internal helper function allows code-reuse within the tests.'''
     submitted_form_data = {}
     if rawHostname is not None:
         submitted_form_data['rawHostname'] = rawHostname
+
+    if domainReservationToken is not None:
+        submitted_form_data['domainReservationToken'] = domainReservationToken
 
     if email is not None:
         submitted_form_data['email'] = email
@@ -409,6 +413,13 @@ def update_benb3_after_recovery(external_ip=True):
         accept_mime_type='text/plain')
 
 
+def reserve_benb4():
+    return _make_api_call(
+        path='reserve',
+        rawHostname='benb4',
+        key_number=None)
+
+
 def get_resolver():
     resolver = dns.resolver.Resolver()
     resolver.reset()
@@ -426,8 +437,12 @@ def reset_app_state():
     # - Restart the sandcats service, if it is enabled.
     os.system('''echo 'drop database if exists sandcats_pdns;' | mysql -uroot''')
     os.system('''cd .. ; make stage-mysql-setup''')
+    # Remove data from the Mongo collections that we use.
     os.system('''printf '\n\ndb.userRegistrations.remove({}); \n\nexit \n ' | mongo sandcats_mongo''')
-    os.system('sudo service sandcats restart')
+    os.system('''printf '\n\ndb.domainReservations.remove({}); \n\nexit \n ' | mongo sandcats_mongo''')
+
+    # Restart the service if it is running via systemd.
+    os.system('sudo service sandcats restart || true')
 
     # We require a restart of the app, if it's in development mode.
     os.system('killall -INT node')
@@ -646,6 +661,60 @@ def test_register():
     assert str(dns_response.rrset) == 'ben-b2.sandcatz.io. 60 IN A 127.0.0.1'
 
 
+def test_reserve_domain():
+    # Per sandcats issue #119, we support reserving a domain, which generates a "domain registration
+    # token", which then can be used against the /registerreserved API to actually set up the
+    # sandcats key and generate a HTTPS keypair.
+
+    # Test some things that should fail to reserve properly.
+
+    # A domain name in the blacklist.
+    response = _make_api_call(path='reserve', key_number=None, rawHostname='ftp')
+    assert response.status_code == 400, response.content
+
+    # A domain name that is already in use.
+    response = _make_api_call(path='reserve', key_number=None, rawHostname='benb2')
+    assert response.status_code == 400, response.content
+
+    # A domain name that is fresh, but missing the email address.
+    response = _make_api_call(path='reserve', key_number=None, email=None, rawHostname='benb4')
+    assert response.status_code == 400, response.content
+
+    # All good. Do the real thing.
+    response = reserve_benb4()
+    assert response.status_code == 200, response.content
+    parsed_content = response.json()
+
+    # We need to allow web browsers to POST to /reserve from JS running on any domain.
+    cors_header = response.headers.get('Access-Control-Allow-Origin', '')
+    assert cors_header == '*', cors_header
+
+    # Make sure we got back some kind of reasonable, non-empty token.
+    token = parsed_content['token']
+    assert len(token) == 40
+
+    # Demonstrate that /recover returns status 400 even for the "right" token.
+    response = _make_api_call(path='recover',
+                              recoveryToken=('a' * 40),
+                              rawHostname='benb4',
+                              key_number=5)
+    assert response.status_code == 400, response.content
+
+
+    # Demonstrate that /registerreserved returns 400 for wrong token and 200 for right token.
+    response = _make_api_call(path='registerreserved',
+                              domainReservationToken=('a' * 40),
+                              rawHostname='benb4',
+                              key_number=5)
+    assert response.status_code == 400, response.content
+
+    response = _make_api_call(path='registerreserved',
+                              domainReservationToken=token,
+                              rawHostname='benb4',
+                              key_number=5)
+    assert response.status_code == 200, response.content
+
+
 def test_recovery():
     # Per sandcats issue #49, we support the ability for users to
     # request an email to be sent to them that grants them
@@ -811,4 +880,5 @@ if __name__ == '__main__':
     test_register()
     test_recovery()
     test_update()
+    test_reserve_domain()
     test_udp_protocol()

--- a/sandcats/lib/collections.js
+++ b/sandcats/lib/collections.js
@@ -14,7 +14,7 @@ var recoveryTokenSchema = new SimpleSchema({
     max: 40
   },
   timestamp: {
-    // Rely in Javascript+Mongo+etc. to avoid timezone problems, since
+    // Rely on Javascript+Mongo+etc. to avoid timezone problems, since
     // in JS, date objects are timezone-aware by default.
     type: Date
   }
@@ -50,6 +50,31 @@ UserRegistrations.attachSchema(new SimpleSchema({
     // to set the domain to a new public key.
     type: recoveryTokenSchema,
     optional: true
+  }
+}));
+
+// We have a separate collection for reserved domain names, rather
+// than storing them in UserRegistrations somehow. This is because:
+//
+// 1. https://blog.engineyard.com/2011/5-subtle-ways-youre-using-mysql-as-a-queue-and-why-itll-bite-you/
+//
+// 2. It makes the logic simpler. This way, I don't have to create a
+//    special fake value for the required publicKeyId parameter, etc.
+
+DomainReservations = new Mongo.Collection("domainReservations");
+DomainReservations.attachSchema(new SimpleSchema({
+  hostname: hostnameType,
+  emailAddress: {
+    // We use a string here for convenience. We rely on Mesosphere to
+    // validate that this is actually an email address.
+    type: String
+  },
+  recoveryData: {
+    // Reserved domains MUST have recoveryData. We call this a domain
+    // reservation code publicly since the purpose is to create a
+    // domain for the first time. As an implementation detail, it is
+    // the same as a recovery token.
+    type: recoveryTokenSchema
   }
 }));
 

--- a/sandcats/lib/validation.js
+++ b/sandcats/lib/validation.js
@@ -1,5 +1,5 @@
-// Provide a "public key must be unique" rule, for validating the
-// public key. Mesosphere handles making sure it is the right length.
+// Provide a "public key must be unique" rule, for validating the public key. Mesosphere handles
+// making sure it is the right length.
 Mesosphere.registerRule('keyFingerprintUnique', function (fieldValue, ruleValue) {
   if (! ruleValue) {
     // if the user does something like pubkeyUnique:
@@ -16,14 +16,11 @@ Mesosphere.registerRule('keyFingerprintUnique', function (fieldValue, ruleValue)
   return true;
 });
 
-// Provide a "public key must be unique" rule, for validating the
-// public key. Mesosphere handles making sure it is the right length.
-// Add extra constraints about hyphen use: can't start with a hyphen; can't end with
-// a hyphen; can't have two hyphens next to each other.
+// Add extra constraints about hyphen use: can't start with a hyphen; can't end with a hyphen; can't
+// have two hyphens next to each other.
 Mesosphere.registerRule('extraHyphenRegexes', function (fieldValue, ruleValue) {
   if (! ruleValue) {
-    // if the user does something like extraHyphenRegexes: false, they
-    // don't need us to validate.
+    // if the user does something like extraHyphenRegexes: false, they don't need us to validate.
     return true;
   }
 
@@ -150,12 +147,25 @@ Mesosphere.registerAggregate('getCertificateIsAuthorized', function(fields, form
   return hostnameIsWithinReasonableCertificateIssuanceLimits(hostname);
 });
 
+makeTokenExpirationChecker = function(maxStalenessInSeconds) {
+  return function(recoveryData) {
+    var staleness_ms = Date.now() - recoveryData.timestamp.getTime();
+    var staleness = Math.floor(staleness_ms / 1000);
+    if (staleness > maxStalenessInSeconds) {
+      return false;
+    }
+    return true;
+  };
+};
+
+recoveryDataHasAcceptableStaleness = makeTokenExpirationChecker(RECOVERY_TIME_PERIOD_IN_SECONDS);
+
 Mesosphere.registerAggregate('recoveryIsAuthorized', function(fields, formFieldsObject) {
   // Recovery is authorized under the following circumstances.
   //
   // - The domain in question has an entry in UserRegistrations.
   //
-  // - The UserRegistrations has a recoveryData attribute
+  // - The object has a recoveryData attribute.
   //
   // - The recoveryData's timestamp is less than
   //   RECOVERY_TIME_PERIOD_IN_SECONDS old.
@@ -163,6 +173,7 @@ Mesosphere.registerAggregate('recoveryIsAuthorized', function(fields, formFields
   // - The recoveryToken we are given is the same as the one in the
   //   recoveryData.
   var userRegistration = UserRegistrations.findOne({'hostname': formFieldsObject.rawHostname});
+
   if (! userRegistration) {
     return false;
   }
@@ -172,9 +183,7 @@ Mesosphere.registerAggregate('recoveryIsAuthorized', function(fields, formFields
     return false;
   }
 
-  var staleness_ms = Date.now() - recoveryData.timestamp.getTime();
-  var staleness = Math.floor(staleness_ms / 1000);
-  if (staleness > RECOVERY_TIME_PERIOD_IN_SECONDS) {
+  if (! recoveryDataHasAcceptableStaleness(recoveryData)) {
     return false;
   }
 
@@ -319,6 +328,11 @@ Mesosphere.registerRule('hostnameUnused', function (fieldValue, ruleValue) {
     return false;
   }
 
+  // If the hostname is pre-reserved, then block this registration.
+  if (DomainReservations.findOne({hostname: fieldValue})) {
+    return false;
+  }
+
   // Here we block some well-known hostnames; see full discussion in
   // issue #43.
   var wellKnownHostnames = /^(www|mail|email|smtp|mx|ns[0-9]|ftp)$/;
@@ -387,6 +401,35 @@ Mesosphere({
         keyFingerprintUnique: true
       },
     }
+  }
+});
+
+// Create reserveForm validator.
+// TODO:
+// - Make sure you can't reserve a domain that already has a UserRegistration.
+// - Make sure you can't reserve a domain that already has a DomainReservation.
+// - Make sure you can't register a domain that already has a DomainReservation.
+Mesosphere({
+  name: 'reserveForm',
+  fields: {
+    rawHostname: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      transforms: ["clean", "toLowerCase"],
+      rules: {
+        minLength: 1,
+        maxLength: 20,
+        hostnameUnused: true,
+        extraHyphenRegexes: true,
+      }
+    },
+    email: {
+      required: true,
+      format: "email"
+    }
+  },
+  aggregates: {
+    updateIsAuthorized: ['hostnameAndPubkeyMatch', ['rawHostname', 'pubkey']]
   }
 });
 

--- a/sandcats/sandcats.js
+++ b/sandcats/sandcats.js
@@ -42,6 +42,22 @@ Router.map(function() {
     }
   });
 
+  this.route('reserve', {
+    path: '/reserve',
+    where: 'server',
+    action: function() {
+      doReserve(this.request, this.response);
+    }
+  });
+
+  this.route('registerreserved', {
+    path: '/registerreserved',
+    where: 'server',
+    action: function() {
+      doRegisterReserved(this.request, this.response);
+    }
+  });
+
   this.route('sendrecoverytoken', {
     path: '/sendrecoverytoken',
     where: 'server',

--- a/sandcats/server/helpers.js
+++ b/sandcats/server/helpers.js
@@ -1,0 +1,16 @@
+getFormDataFromRequest = function(request) {
+  // The form data is the request body, plus some extra data that we
+  // add as if the user submitted it, for convenience of our own
+  // processing.
+  var rawFormData = _.clone(request.body);
+
+  var clientIp = getClientIpFromRequest(request);
+  rawFormData.ipAddress = clientIp;
+
+  // For easy consistency, and to avoid wasting space, turn
+  // e.g. "ab:cd" into "abcd".
+  var clientCertificateFingerprint = request.headers['x-client-certificate-fingerprint'] || "";
+  rawFormData.pubkey = clientCertificateFingerprint.replace(/:/g, "");
+
+  return rawFormData;
+}

--- a/sandcats/server/register.js
+++ b/sandcats/server/register.js
@@ -1,4 +1,4 @@
-function finishResponse(status, jsonData, response, plainTextOnly) {
+finishResponse = function(status, jsonData, response, plainTextOnly) {
   if (plainTextOnly) {
     // If the client really really wants plain text, then we hope that
     // the jsonData object has a 'text' property.
@@ -21,7 +21,7 @@ function finishResponse(status, jsonData, response, plainTextOnly) {
   response.end(JSON.stringify(jsonData));
 }
 
-function responseFromFormFailure(validatedFormData) {
+responseFromFormFailure = function(validatedFormData) {
   var response = {error: validatedFormData.errors};
 
   // The response['text'] is information that we show to a person
@@ -57,7 +57,7 @@ function responseFromFormFailure(validatedFormData) {
   return response;
 }
 
-function antiCsrf(request, response) {
+antiCsrf = function(request, response) {
   // Two mini anti-cross-site request forgery checks: POST and a
   // custom HTTP header.
   var requestEnded = false;
@@ -72,7 +72,7 @@ function antiCsrf(request, response) {
   return requestEnded;
 }
 
-function getFormDataFromRequest(request) {
+getFormDataFromRequest = function(request) {
   // The form data is the request body, plus some extra data that we
   // add as if the user submitted it, for convenience of our own
   // processing.
@@ -89,7 +89,7 @@ function getFormDataFromRequest(request) {
   return rawFormData;
 }
 
-function getClientIpFromRequest(request) {
+getClientIpFromRequest = function(request) {
   // The X-Real-IP header contains the client's IP address, and since
   // it's a non-standard header, the Meteor built-in proxy does not
   // mess with it. We assume nginx is going to give this to us.
@@ -97,7 +97,7 @@ function getClientIpFromRequest(request) {
   return clientIp || "";
 }
 
-function wantsPlainText(request) {
+wantsPlainText = function(request) {
   // If the HTTP client can only handle a text/plain response, the
   // Sandcats code honors that by throwing away everything but the
   // 'text' key in the object we were going to respond with.
@@ -137,7 +137,7 @@ doRegister = function(request, response) {
 
   // Give the user an indication of our success.
   return finishResponse(200, {
-    'success': true, 'text': "Successfully registered!"
+    'success': true, 'text': "Successfully registered!",
   }, response, plainTextOnly);
 }
 
@@ -304,7 +304,8 @@ doRecover = function(request, response) {
   }
 }
 
-function createUserRegistration(formData) {
+createUserRegistration = function(formData) {
+  console.log("YOW", JSON.stringify(formData));
   // To create a user registration, we mostly copy data from the form.
   // We do also need to store a public key "fingerprint", which for
   // now we calculated as deadbeaf.
@@ -318,6 +319,12 @@ function createUserRegistration(formData) {
     emailAddress: formData.email
   });
 
+  // Provide some non-empty recovery token, and return that to the
+  // createUserRegistration caller. This value finds its way into the
+  // JSON response.
+
+  var recoveryToken = addRecoveryData(formData);
+
   var userRegistration = UserRegistrations.findOne({_id: userRegistrationId});
 
   // We also probably want to send a confirmation URL. FIXME.
@@ -330,6 +337,15 @@ function createUserRegistration(formData) {
     mysqlQuery,
     userRegistration.hostname,
     userRegistration.ipAddress);
+
+  return recoveryToken;
+}
+
+generateRecoveryData = function() {
+  var recoveryData = {}
+  recoveryData.recoveryToken = Random.id(40);
+  recoveryData.timestamp = new Date();
+  return recoveryData;
 }
 
 function addRecoveryData(formData) {
@@ -340,9 +356,7 @@ function addRecoveryData(formData) {
   // as we can send them a token by email.
 
   // Generate some recovery data.
-  var recoveryData = {}
-  recoveryData.recoveryToken = Random.id(40);
-  recoveryData.timestamp = new Date();
+  var recoveryData = generateRecoveryData();
 
   // Always just toss it onto the corresponding UserRegistration
   // record. (We will only send the recoveryToken to email address

--- a/sandcats/server/reservedomain.js
+++ b/sandcats/server/reservedomain.js
@@ -1,0 +1,213 @@
+// This file contains the functions that handle tasks related to reserving domain names with a
+// token.
+
+// Create validator for turning a domainReservationToken into a registered domain.
+//
+// If a user gives us a valid form like this, we create a domain on their behalf. We need less info
+// in this, compared to registerForm, because the personal info was already submitted as part of
+// reserving the domain name.
+Mesosphere({
+  name: 'reservedDomainRegisterForm',
+  fields: {
+    domainReservationToken: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      rules: {
+        minLength: 40,
+        maxLength: 40
+      },
+    },
+    rawHostname: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      transforms: ["clean", "toLowerCase"],
+      rules: {
+        minLength: 1,
+        maxLength: 20
+      }
+    },
+    pubkey: {
+      required: true,
+      rules: {
+        minLength: 40,
+        maxLength: 40,
+        keyFingerprintUnique: true
+      },
+    }
+  },
+  aggregates: {
+    domainReservationTokenUseIsAuthorized: ['domainReservationTokenUseIsAuthorized',
+                                             ['rawHostname', 'domainReservationToken']]
+  }
+});
+
+// Give the user half an hour to use this token. They had better hurry.
+var MAX_STALENESS_IN_SECONDS = 30 * 60;
+var domainReservationTokenHasAcceptableStaleness = makeTokenExpirationChecker(
+  MAX_STALENESS_IN_SECONDS);
+
+
+Mesosphere.registerAggregate('domainReservationTokenUseIsAuthorized', function(fields, formFieldsObject) {
+  // Using a domain registration token is authorized under the following circumstances.
+  //
+  // - The domain in question has an entry in DomainReservations.
+  //
+  // - The object has a recoveryData attribute.
+  //
+  // - The recoveryData's timestamp is less than RECOVERY_TIME_PERIOD_IN_SECONDS old.
+  //
+  // - The recoveryToken we are given is the same as the one in the recoveryData.
+  var datum = DomainReservations.findOne({'hostname': formFieldsObject.rawHostname});
+
+  if (! datum) {
+    return false;
+  }
+
+  var recoveryData = datum.recoveryData;
+  if (! recoveryData) {
+    return false;
+  }
+
+  if (! domainReservationTokenHasAcceptableStaleness(recoveryData)) {
+    return false;
+  }
+
+  if (formFieldsObject.domainReservationToken == recoveryData.recoveryToken) {
+    return true;  // hooray!
+  }
+
+  return false;
+});
+
+// HTTP response functions, aka "views".
+
+doRegisterReserved = function(request, response) {
+  // This gets called via install.sh, when someone wants to actually register a domain they've
+  // reserved.
+  //
+  // - Client submits a form that is basically the same as recover, but using a
+  //   domainReservationToken.
+  //
+  // - We create their domain for them.
+  console.log("Beginning registration of reserved domain.");
+
+  var requestEnded = antiCsrf(request, response);
+  if (requestEnded) {
+    return;
+  }
+
+  var rawFormData = getFormDataFromRequest(request);
+  var plainTextOnly = wantsPlainText(request);
+
+  var validatedFormData = Mesosphere.reservedDomainRegisterForm.validate(rawFormData);
+  if (validatedFormData.errors) {
+    return finishResponse(400,
+                          responseFromFormFailure(validatedFormData),
+                          response,
+                          plainTextOnly);
+  }
+  if (! validatedFormData.formData.domainReservationTokenUseIsAuthorized) {
+    return finishResponse(400, {
+      'text':
+      'Bad domainReservationToken. If you are an end user, contact your Sandstorm hosting provider.'
+    }, response, plainTextOnly);
+  }
+
+  // Great! It passed all our validation. Enrich the submitted form with information
+  // from DomainReservations.
+  var reservation = DomainReservations.findOne({
+    "recoveryData.recoveryToken": validatedFormData.formData.domainReservationToken,
+    "hostname": validatedFormData.formData.rawHostname,
+  });
+  if (! reservation) {
+    console.log("*** ERROR ***: Ran into a mis-hap while attempting to register reserved domain.");
+    console.log("Form submission:", JSON.stringify(validatedFormData));
+    return finishResponse(500, {
+      'text': 'Server error E101. Please email support@sandstorm.io to get help.'
+    }, response, plainTextOnly);
+  }
+
+  var userRegistration = {
+    rawHostname: validatedFormData.formData.rawHostname,
+    ipAddress: validatedFormData.formData.ipAddress,
+    pubkey: validatedFormData.formData.pubkey,
+    email: reservation.emailAddress,
+  };
+
+  createUserRegistration(userRegistration);
+
+  // Now that we've registered them, destroy the reservation.
+  DomainReservations.remove({_id: reservation._id});
+
+  // Give the user an indication of our success.
+  return finishResponse(200, {
+    'success': true, 'text': "Successfully registered!",
+  }, response, plainTextOnly);
+
+}
+
+
+doReserve = function(request, response) {
+  // Reserving a domain name is where you give us a name+email address for a domain, and get a
+  // recoveryToken back (which we call a domainReservationToken). We don't create a real
+  // UserRegistration and we don't store any client cert.
+  //
+  // Everyone is allowed to reserve a domain. This creates a DomainReservations document whose
+  // recoveryToken data hints at a timestamp.
+  //
+  // In the future, we might:
+  //
+  // - Limit which IP addresses can use this API
+  //
+  // - Ask people to register with us before using it
+  //
+  // But for now, enjoy the free-for-all.
+  console.log("Beginning domain reservation process.");
+
+  // Unlike other service endpoints, doReserve is allowed to be accessed via a browser. So we skip
+  // the check for the ability to send a custom header. We do still check that this is a POST.
+  if (request.method != 'POST') {
+    return;
+  }
+
+  // The purpose of this endpoint is to generate a token that is consumed by Javascript operating on
+  // an arbitrary origin. So allow it.
+  response.setHeader('Access-Control-Allow-Origin', '*');
+
+  // By the way, you might wonder - won't browsers attempt to submit a client certificate if they
+  // have one? The answer is "No, so long as {withCredentials: false} is part of the XMLHttpRequest
+  // invocation."
+
+  var plainTextOnly = false;
+  var rawFormData = getFormDataFromRequest(request);
+  var validatedFormData = Mesosphere.reserveForm.validate(rawFormData);
+  if (validatedFormData.errors) {
+    return finishResponse(400,
+                          responseFromFormFailure(validatedFormData),
+                          response,
+                          plainTextOnly);
+  }
+
+  // Great! It passed all our validation. Let's reserve the domain.
+  var recoveryToken = createDomainReservation(validatedFormData.formData);
+
+  // Give the user an indication of our success.
+  return finishResponse(200, {
+    'success': true, 'text': "Successfully registered!",
+    'token': recoveryToken,
+  }, response, plainTextOnly);
+}
+
+
+
+// Functions to actually store data in the database.
+function createDomainReservation(formData) {
+  console.log("Reserving domain with data", JSON.stringify(formData));
+  var recoveryData = generateRecoveryData();
+  var domainReservationId = DomainReservations.insert({
+    hostname: formData.rawHostname,
+    emailAddress: formData.email,
+    recoveryData: recoveryData
+  });
+  return recoveryData.recoveryToken;
+}


### PR DESCRIPTION
Details:
- Create two new HTTP API methods, /reserve and /registerreserved
- Create a new Mongo collection for DomainReservations
- Adjust registration flow to block registering reserved domains
- Add tests for /reserve to make sure you cannot reserve domains that
  are already in use, and that an email address is required, as well
  as testing the successful /reserve => /registerreserved flow
