### PR TITLE
Fix ability to store errors from GlobalSign

### DIFF
--- a/sandcats/lib/collections.js
+++ b/sandcats/lib/collections.js
@@ -94,8 +94,9 @@ CertificateRequests.attachSchema(new SimpleSchema({
   globalsignValidityPeriod: {
     type: Object
   },
-  globalsignErrorMessages: {
-    type: [String],
+  globalsignErrors: {
+    type: Object,
+    blackbox: true,
     optional: true
   },
   "globalsignValidityPeriod.Months": {

--- a/sandcats/lib/globalsign.js
+++ b/sandcats/lib/globalsign.js
@@ -249,8 +249,8 @@ logIssueCertificateSuccess = function(globalsignResponse, logEntryId) {
 
 logIssueCertificateErrors = function(errorList, logEntryId) {
   console.log("Attempting to store", errorList, "w/r/t", logEntryId);
-  var numAffected = CertificateRequests.update({'_id': logEntryId}, {$set: {
-    globalsignErrors: errorList}});
+  var numAffected = CertificateRequests.update({_id: logEntryId},
+                                               {$set: {globalsignErrors: errorList}});
   if (numAffected != 1) {
     throw new Error("logIssueCertificateErrors changed " + numAffected +
                     " documents when it meant to change 1. ID was: ",


### PR DESCRIPTION
Thanks a lot to myself in the past for using a MongoDB schema package that would
later confuse me greatly. On the whole, though, good choice.
