### PR TITLE
Add endpoint to answer ACME DNS-01 challenges.

### DIFF
--- a/sandcats/lib/dns.js
+++ b/sandcats/lib/dns.js
@@ -78,6 +78,26 @@ publishOneUserRegistrationToDns = function(mysqlQuery, hostname, ipAddress) {
   bumpSoaRecord(mysqlQuery, Meteor.settings.BASE_DOMAIN);
 }
 
+function deleteSpecialHostRecords(wrappedQuery, domain, host) {
+  var result = wrappedQuery(
+    "DELETE from `records` WHERE (domain_id = (SELECT `id` from `domains` WHERE `name` = ?)) AND " +
+      "name = ?",
+    [domain, host]);
+  console.log("Successfully deleted record(s) for " + host + "." + "with status " + JSON.stringify(result) + ".");
+};
+
+publishAcmeChallengeToDns = function(mysqlQuery, hostname, value) {
+  // Push two TXT records to _acme-challenge.hostname.
+
+  var txtHost = '_acme-challenge.' + hostname + '.' + Meteor.settings.BASE_DOMAIN;
+
+  if (value) {
+    rawCreateRecord(mysqlQuery, Meteor.settings.BASE_DOMAIN, txtHost, 'TXT', value);
+  } else {
+    deleteSpecialHostRecords(mysqlQuery, Meteor.settings.BASE_DOMAIN, txtHost);
+  }
+}
+
 // Private functions.
 
 // This function adds a DNS record to PowerDNS's MySQL data store.

--- a/sandcats/lib/validation.js
+++ b/sandcats/lib/validation.js
@@ -462,6 +462,39 @@ Mesosphere({
   }
 });
 
+// Create validator for an ACME challenge request.
+Mesosphere({
+  name: 'acmeChallenge',
+  fields: {
+    rawHostname: {
+      required: true,
+      format: /^[0-9a-zA-Z-]+$/,
+      transforms: ["clean", "toLowerCase"],
+      rules: {
+        minLength: 1,
+        maxLength: 20
+      }
+    },
+    value: {
+      required: false,
+      format: /^[ -~]*$/,
+      rules: {
+        maxLength: 255
+      }
+    },
+    pubkey: {
+      required: true,
+      rules: {
+        minLength: 40,
+        maxLength: 40
+      },
+    }
+  },
+  aggregates: {
+    isAuthorized: ['hostnameAndPubkeyMatch', ['rawHostname', 'pubkey']]
+  }
+});
+
 // Create validator for recovery token sending request.
 Mesosphere({
   name: 'recoverDomainForm',

--- a/sandcats/sandcats.js
+++ b/sandcats/sandcats.js
@@ -82,6 +82,14 @@ Router.map(function() {
     }
   });
 
+  this.route('acme-challenge', {
+    path: '/acme-challenge',
+    where: 'server',
+    action: function() {
+      doAcmeChallenge(this.request, this.response);
+    }
+  });
+
   this.route('getcertificate', {
     path: '/getcertificate',
     where: 'server',


### PR DESCRIPTION
The Let's Encrypt API will be invoked from the user's own Sandstorm server. The Sandcats.io server only needs to provide a way to publish TXT records to pass ACME challenges.